### PR TITLE
fix: remove stale reindex vault_config kwarg

### DIFF
--- a/src/ctxvault/core/vaults/semantic.py
+++ b/src/ctxvault/core/vaults/semantic.py
@@ -52,7 +52,7 @@ class SemanticVault(BaseVault):
 
         for file in self.iter_files(path=base_path, exclude_dirs=[self.db_path]):
             try:
-                self.reindex_file(file_path=file, vault_config=self.config)
+                self.reindex_file(file_path=file)
                 reindexed_files.append(str(file))
             except Exception as e:
                 skipped_files.append(f"{str(file)} ({e})")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,7 +53,9 @@ def test_cli_delete_semantic(mock_vault_config, temp_docs):
 def test_cli_reindex_semantic(mock_vault_config):
     result = runner.invoke(app, ["reindex", "test_vault"])
     assert result.exit_code == 0
-    assert "Reindexed:" in result.stdout or "Skipped:" in result.stdout
+    assert "Reindexed: 2" in result.stdout
+    assert "Skipped: 0" in result.stdout
+    assert "unexpected keyword argument 'vault_config'" not in result.stdout
 
 @pytest.mark.usefixtures("mock_chroma", "temp_docs")
 def test_cli_docs_semantic(mock_vault_config):


### PR DESCRIPTION
Fixes #25.

## Summary
- Stop passing the stale `vault_config` keyword from `SemanticVault.reindex_files()` into `SemanticVault.reindex_file()`.
- Tighten the CLI reindex regression test so it requires two reindexed files, zero skipped files, and no `vault_config` keyword error in output.

## Test plan
- `uv run --extra dev pytest tests/test_cli.py::test_cli_reindex_semantic`
- `uv run --extra dev pytest tests/test_cli.py tests/test_core.py`
- `git diff --check`

Note: `uv run --extra dev black --check src/ctxvault/core/vaults/semantic.py tests/test_cli.py` currently wants to reformat both files and emits a Python target-version warning in this environment, so I avoided formatting churn unrelated to this one-line fix.
