### PR TITLE
feat: configurable embedding model per vault (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ attached agents. Pass `--type skill` to create a skill vault for procedural memo
 instead of the default semantic vault.
 
 ```bash
-ctxvault init <name> [--type <type>] [--path <path>] [--global] [--restricted]
+ctxvault init <name> [--type <type>] [--path <path>] [--global] [--restricted] [--embedding-model <model>]
 ```
 
 **Arguments:**
@@ -319,6 +319,7 @@ ctxvault init <name> [--type <type>] [--path <path>] [--global] [--restricted]
 - `--path <path>` - Custom vault location (optional, default: `~/.ctxvault/vaults/<name>`)
 - `--global` - Create a global vault in ~/.ctxvault, available from anywhere on the machine
 - `--restricted` - Create vault as restricted (optional, default: public)
+- `--embedding-model <model>` - sentence-transformers model for this semantic vault (optional, default: `all-MiniLM-L6-v2`). The model is pinned at init time and used for all indexing and querying on the vault. Semantic vaults only.
 
 
 **Example:**
@@ -327,6 +328,7 @@ ctxvault init my-vault                          # semantic vault (default)
 ctxvault init my-vault --type skill             # skill vault for procedural memory
 ctxvault init my-vault --global --type skill    # global skill vault
 ctxvault init my-vault --restricted
+ctxvault init my-vault --embedding-model all-mpnet-base-v2   # custom embedding model
 ```
 
 ---

--- a/src/ctxvault/cli/app.py
+++ b/src/ctxvault/cli/app.py
@@ -31,13 +31,17 @@ def _print_vault(v: dict):
 
     typer.echo("")
     typer.secho(f"  {'path:':<20}{v['vault_path']}", fg=typer.colors.BRIGHT_BLACK)
+    # Surface a non-default embedding model so `vaults` shows which model a
+    # semantic vault is pinned to; default vaults omit the key and print nothing.
+    if v.get("embedding_model"):
+        typer.secho(f"  {'embedding model:':<20}{v['embedding_model']}", fg=typer.colors.BRIGHT_BLACK)
     typer.echo("")
 
 @app.command()
-def init(name: str = typer.Argument("my-vault"), type: str = typer.Option(VaultType.SEMANTIC.value, "--type"), restricted: bool = typer.Option(False, "--restricted"), path: str = typer.Option(None, "--path"), global_vault: bool = typer.Option(False, "--global")):
+def init(name: str = typer.Argument("my-vault"), type: str = typer.Option(VaultType.SEMANTIC.value, "--type"), restricted: bool = typer.Option(False, "--restricted"), path: str = typer.Option(None, "--path"), global_vault: bool = typer.Option(False, "--global"), embedding_model: str = typer.Option(None, "--embedding-model", help="sentence-transformers model for this semantic vault (default: all-MiniLM-L6-v2)")):
     try:
         typer.echo(f"Initializing Context Vault {name}...")
-        vault_path, config_path = vault_router.init_vault(vault_name=name, vault_type=type, restricted=restricted, path=path, global_vault=global_vault)
+        vault_path, config_path = vault_router.init_vault(vault_name=name, vault_type=type, restricted=restricted, path=path, global_vault=global_vault, embedding_model=embedding_model)
         typer.secho("Context Vault initialized succesfully!", fg=typer.colors.GREEN, bold=True)
         typer.echo(f"Context Vault path: {vault_path}")
         typer.echo(f"Config file path: {config_path}")

--- a/src/ctxvault/core/embedding.py
+++ b/src/ctxvault/core/embedding.py
@@ -2,11 +2,18 @@ import logging
 import transformers
 from sentence_transformers import SentenceTransformer
 
-MODEL: SentenceTransformer = None
+DEFAULT_EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 
-def get_model():
-    global MODEL
-    if MODEL is None:
+# Cache one SentenceTransformer per model name. A vault pins its model at init
+# time (see `ctxvault init --embedding-model`), so a process touching several
+# vaults may need more than one model loaded; keying by name keeps each loaded
+# exactly once while still supporting per-vault models.
+_MODELS: dict[str, SentenceTransformer] = {}
+
+def get_model(model_name: str | None = None) -> SentenceTransformer:
+    name = model_name or DEFAULT_EMBEDDING_MODEL
+    model = _MODELS.get(name)
+    if model is None:
         loggers = [
             "sentence_transformers",
             "transformers",
@@ -17,9 +24,9 @@ def get_model():
             "huggingface_hub._commit_api",
         ]
         original_levels = {}
-        for name in loggers:
-            logger = logging.getLogger(name)
-            original_levels[name] = logger.level
+        for logger_name in loggers:
+            logger = logging.getLogger(logger_name)
+            original_levels[logger_name] = logger.level
             logger.setLevel(logging.ERROR)
 
         original_verbosity = transformers.logging.get_verbosity()
@@ -27,14 +34,16 @@ def get_model():
         transformers.logging.disable_progress_bar()
 
         try:
-            MODEL = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+            model = SentenceTransformer(name)
         finally:
             transformers.logging.set_verbosity(original_verbosity)
             transformers.logging.enable_progress_bar()
-            for name, level in original_levels.items():
-                logging.getLogger(name).setLevel(level)
+            for logger_name, level in original_levels.items():
+                logging.getLogger(logger_name).setLevel(level)
 
-    return MODEL
+        _MODELS[name] = model
 
-def embed_list(chunks: list[str]) -> list[list[float]]:
-    return get_model().encode(sentences=chunks, show_progress_bar=False).tolist()
+    return model
+
+def embed_list(chunks: list[str], model_name: str | None = None) -> list[list[float]]:
+    return get_model(model_name).encode(sentences=chunks, show_progress_bar=False).tolist()

--- a/src/ctxvault/core/indexer.py
+++ b/src/ctxvault/core/indexer.py
@@ -11,7 +11,9 @@ def index_file(file_path: str, config: dict, agent_metadata: dict | None = None)
 
     chunks = chunking(text, file_type=file_type)
 
-    embeddings = embed_list(chunks=chunks)
+    # Use the model pinned to this vault (config["embedding_model"]); falls back
+    # to the default model when the vault was created without an override.
+    embeddings = embed_list(chunks=chunks, model_name=config.get("embedding_model"))
 
     chunk_ids, metadatas = build_chunks_metadatas(doc_id=doc_id, chunks_size=len(chunks), source=file_path, filetype=file_type, agent_metadata=agent_metadata)
 

--- a/src/ctxvault/core/querying.py
+++ b/src/ctxvault/core/querying.py
@@ -37,7 +37,9 @@ def build_documents_from_metadatas(metadatas)-> list[SemanticDocumentInfo]:
     ]
 
 def query(query_txt: str, config: dict, n_results: int = 5, filters: dict | None = None)-> dict:
-    query_embedding = embed_list(chunks=[query_txt])
+    # Query must embed with the same model used to index this vault, or the
+    # vectors are not comparable; both read it from the vault config.
+    query_embedding = embed_list(chunks=[query_txt], model_name=config.get("embedding_model"))
     return chroma_store.query(query_embedding=query_embedding, config=config, n_results=n_results, filters=filters)
 
 def list_documents(config: dict)-> list[SemanticDocumentInfo]:

--- a/src/ctxvault/core/vault_router.py
+++ b/src/ctxvault/core/vault_router.py
@@ -45,14 +45,14 @@ def purge_vault(vault_name: str) -> None:
     vault = _get_vault(vault_name=vault_name)
     vault.purge_vault()
 
-def init_vault(vault_name: str, vault_type: str | VaultType = VaultType.SEMANTIC, restricted: bool = False, path: str | None = None, global_vault: bool = False)-> tuple[str, str]:
+def init_vault(vault_name: str, vault_type: str | VaultType = VaultType.SEMANTIC, restricted: bool = False, path: str | None = None, global_vault: bool = False, embedding_model: str | None = None)-> tuple[str, str]:
     if isinstance(vault_type, str):
         try:
             vault_type = VaultType(vault_type)
         except ValueError:
             raise VaultTypeNotValidError(f"Vault type not valid: {vault_type}. Choose between: {', '.join(VaultType.list())}")
-    
-    vault_path, config_path = create_vault(vault_name=vault_name, vault_type=vault_type, restricted=restricted, vault_path=path, global_vault=global_vault)
+
+    vault_path, config_path = create_vault(vault_name=vault_name, vault_type=vault_type, restricted=restricted, vault_path=path, global_vault=global_vault, embedding_model=embedding_model)
     return str(vault_path), config_path
 
 def index_files(vault_name: str, path: str | None = None)-> tuple[list[str], list[str]]:

--- a/src/ctxvault/utils/config.py
+++ b/src/ctxvault/utils/config.py
@@ -59,7 +59,12 @@ def _get_vault_scope(vault_name: str, global_config: dict, local_config: dict) -
         return "global"
     return None
 
-def create_vault(vault_name: str, vault_type: VaultType, restricted: bool, vault_path: str | None, global_vault: bool = False) -> tuple[str, str]:
+def create_vault(vault_name: str, vault_type: VaultType, restricted: bool, vault_path: str | None, global_vault: bool = False, embedding_model: str | None = None) -> tuple[str, str]:
+    # Embedding only happens in semantic vaults; skill vaults are curated and
+    # never indexed, so a model override there would be silently meaningless.
+    if embedding_model and vault_type != VaultType.SEMANTIC:
+        raise ValueError("--embedding-model is only supported for semantic vaults.")
+
     if global_vault:
         global_config, _, _ = _load_config()
         config = global_config
@@ -88,13 +93,19 @@ def create_vault(vault_name: str, vault_type: VaultType, restricted: bool, vault
 
     vault_path_final = vault_path_abs.as_posix() if global_vault else vault_path_abs.relative_to(save_root.parent).as_posix()
 
-    config["vaults"][vault_name] = {
-        "type": vault_type.value, 
+    entry = {
+        "type": vault_type.value,
         "vault_path": vault_path_final,
         "db_path": db_path_posix,
         "restricted": restricted,
         "allowed_agents": []
     }
+    # Store the model only when overridden, so existing/default vaults keep their
+    # current config shape and resolve to embedding.DEFAULT_EMBEDDING_MODEL.
+    if embedding_model:
+        entry["embedding_model"] = embedding_model
+
+    config["vaults"][vault_name] = entry
 
     _save_config(data=config, root=save_root)
     return str(vault_path_abs), str(_config_file(save_root))
@@ -112,7 +123,8 @@ def get_vaults() -> list[dict]:
             "vault_path": data.get("vault_path"),
             "db_path": data.get("db_path"),
             "restricted": data.get("restricted"),
-            "allowed_agents": data.get("allowed_agents")
+            "allowed_agents": data.get("allowed_agents"),
+            "embedding_model": data.get("embedding_model")
         })
 
     for name, data in global_config["vaults"].items():
@@ -123,7 +135,8 @@ def get_vaults() -> list[dict]:
             "vault_path": data.get("vault_path"),
             "db_path": data.get("db_path"),
             "restricted": data.get("restricted"),
-            "allowed_agents": data.get("allowed_agents")
+            "allowed_agents": data.get("allowed_agents"),
+            "embedding_model": data.get("embedding_model")
         })
 
     return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 def mock_chroma(monkeypatch):
     monkeypatch.setattr(
         "ctxvault.core.embedding.embed_list",
-        lambda chunks: [[0.1] * 384] * len(chunks),
+        lambda chunks, model_name=None: [[0.1] * 384] * len(chunks),
     )
 
     mock_collection = MagicMock()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,3 +138,21 @@ def test_cli_delete_purge(mock_vault_config):
     result = runner.invoke(app, ["delete", "test_vault", "--purge"])
     assert result.exit_code == 0
     assert "permanently deleted" in result.stdout
+
+# ── Embedding model option (#18) ─────────────────────────────────────────────
+
+def test_cli_init_with_embedding_model(mock_global_config):
+    from ctxvault.utils.config import get_vaults
+    result = runner.invoke(
+        app, ["init", "cli_model_vault", "--global", "--embedding-model", "all-mpnet-base-v2"]
+    )
+    assert result.exit_code == 0
+    vault = next(v for v in get_vaults() if v["name"] == "cli_model_vault")
+    assert vault["embedding_model"] == "all-mpnet-base-v2"
+
+def test_cli_init_embedding_model_rejected_for_skill(mock_global_config):
+    result = runner.invoke(
+        app, ["init", "skill_model_vault", "--type", "skill", "--embedding-model", "x"]
+    )
+    assert result.exit_code == 1
+    assert "semantic" in result.stdout.lower()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -182,3 +182,77 @@ def test_chunking_new_defaults():
     sig = inspect.signature(chunking)
     assert sig.parameters["chunk_size"].default == 400
     assert sig.parameters["overlap"].default == 100
+
+# ── Per-vault embedding model (#18) ─────────────────────────────────────────
+
+def test_init_vault_stores_embedding_model(mock_global_config):
+    from ctxvault.utils.config import get_vaults
+    vault_router.init_vault(
+        vault_name="custom_model_vault", global_vault=True,
+        embedding_model="all-mpnet-base-v2"
+    )
+    vault = next(v for v in get_vaults() if v["name"] == "custom_model_vault")
+    assert vault["embedding_model"] == "all-mpnet-base-v2"
+
+def test_init_vault_default_has_no_embedding_model(mock_vault_config):
+    from ctxvault.utils.config import get_vaults
+    vault = next(v for v in get_vaults() if v["name"] == "test_vault")
+    assert vault["embedding_model"] is None
+
+def test_init_vault_rejects_embedding_model_for_skill(mock_global_config):
+    with pytest.raises(ValueError):
+        vault_router.init_vault(
+            vault_name="skill_with_model", vault_type="skill",
+            global_vault=True, embedding_model="all-mpnet-base-v2"
+        )
+
+def test_index_threads_vault_embedding_model(mock_global_config, monkeypatch):
+    vault_path, _ = vault_router.init_vault(
+        vault_name="idx_vault", global_vault=True,
+        embedding_model="all-mpnet-base-v2"
+    )
+    (Path(vault_path) / "doc.txt").write_text("hello world")
+
+    seen = []
+    def recording_embed(chunks, model_name=None):
+        seen.append(model_name)
+        return [[0.1] * 384] * len(chunks)
+    monkeypatch.setattr("ctxvault.core.embedding.embed_list", recording_embed)
+
+    vault_router.index_files(vault_name="idx_vault")
+    assert seen and all(model == "all-mpnet-base-v2" for model in seen)
+
+def test_query_threads_vault_embedding_model(mock_global_config, monkeypatch):
+    vault_router.init_vault(
+        vault_name="qry_vault", global_vault=True,
+        embedding_model="all-mpnet-base-v2"
+    )
+
+    seen = []
+    def recording_embed(chunks, model_name=None):
+        seen.append(model_name)
+        return [[0.1] * 384] * len(chunks)
+    # querying.py binds embed_list at import, so patch it where it is looked up.
+    monkeypatch.setattr("ctxvault.core.querying.embed_list", recording_embed)
+
+    vault_router.query(text="anything", vault_name="qry_vault")
+    assert seen == ["all-mpnet-base-v2"]
+
+def test_get_model_caches_per_name_and_defaults(monkeypatch):
+    import ctxvault.core.embedding as embedding
+
+    created = []
+    class FakeSentenceTransformer:
+        def __init__(self, name):
+            self.name = name
+            created.append(name)
+    monkeypatch.setattr(embedding, "SentenceTransformer", FakeSentenceTransformer)
+    monkeypatch.setattr(embedding, "_MODELS", {})
+
+    first = embedding.get_model("model-a")
+    again = embedding.get_model("model-a")
+    default = embedding.get_model()
+
+    assert first is again  # same name -> cached instance reused
+    assert default is not first  # default model is a distinct instance
+    assert created == ["model-a", embedding.DEFAULT_EMBEDDING_MODEL]


### PR DESCRIPTION
## What

Closes #18. Allow choosing the sentence-transformers embedding model per vault, configured at init time:

```bash
ctxvault init my-vault --embedding-model all-mpnet-base-v2
```

The model is stored in the vault's `config.json` and used for all indexing and querying on that vault. Omitting the flag keeps the current default (`all-MiniLM-L6-v2`).

## Why

The embedding model was hardcoded in `core/embedding.py`. Different domains (code, legal, medical, multilingual) benefit significantly from specialized models, and users shouldn't have to edit source to pick one.

## How

- **`core/embedding.py`** — the global `MODEL` singleton becomes a per-name cache: `get_model(model_name)` / `embed_list(chunks, model_name)`, with `DEFAULT_EMBEDDING_MODEL` as the fallback. A process touching several vaults loads each model exactly once.
- **`utils/config.create_vault`** — accepts `embedding_model` and stores it in the vault entry **only when overridden**, so existing/default vaults keep their current config shape and resolve to the default. Passing it for a non-semantic (skill) vault fails fast, consistent with the issue's "semantic vaults only" constraint.
- **`core/indexer` + `core/querying`** — read the model from the vault `config` (already threaded to both) and pass it to `embed_list`, so a query always embeds with the same model used to index — vectors stay comparable. No config migration; model is pinned at init.
- **`cli/app.py`** — `--embedding-model` option on `init`; the `vaults` listing surfaces a vault's pinned model for observability.

## Constraints honored (per the issue)

- Local-only: sentence-transformers models, no API keys / external services.
- Per-vault, set at init, no switching after init → no re-index/migration path needed.

## Tests

Added to `tests/test_core.py` and `tests/test_cli.py`:
- init stores `embedding_model` in config; default vaults store nothing and resolve to the default
- `--embedding-model` on a skill vault is rejected
- `index` and `query` thread the vault's configured model to `embed_list`
- `get_model` caches one instance per model name and falls back to the default

Updated `conftest.py`'s `embed_list` stub to the new signature, and documented the flag in the README.

**Verification:** full suite `pytest` — 91 passed (the new tests fail on `main`). No `uv.lock` or unrelated changes.